### PR TITLE
convertToH5_JK

### DIFF
--- a/conversion.asv
+++ b/conversion.asv
@@ -20,7 +20,7 @@ elapsedTimes = zeros(length(sessions),1);
 
 targetBD = 'D:\TPM\JK\h5\';
 % %%
-parfor si = 1 : length(sessions)
+for si = 1 : length(sessions)
 % for si = 1
     tic
     sbxList = ls(sprintf('%s%03d\\%03d_%03d_0*.sbx',baseDir,mouse,mouse,sessions(si)));

--- a/conversion.m
+++ b/conversion.m
@@ -36,7 +36,7 @@ parfor si = 1 : length(sessions)
         optotuneRingingTime = 8; % in ms. To crop top portion of each frame.
 
         targetDir = sprintf('%s%03d\\',targetBD,mouse);
-        convertToH5_JK(fn,targetDir)
+        convertToH5_JK(fn,targetDir,optotuneRingingTime)
     end
     elapsedTimes(si) = toc;
 end

--- a/convertToH5.m
+++ b/convertToH5.m
@@ -36,7 +36,7 @@ function [] = convertToH5(sessionName)
        % check frame dims
        q = sbxread(sessionName, 1, 1);
        q = squeeze(q);
-       q = q(:,100:end-100);
+       q = q(:,100:end-10);
        meanImg = q;
 
        h5create(planeFile, '/data', [size(q, 1), size(q, 2) Inf], 'DataType', 'uint16', 'ChunkSize',[size(q,1) size(q,2) 1])
@@ -50,7 +50,7 @@ function [] = convertToH5(sessionName)
        for f = framePlanes{1, i}
           q = sbxread(sessionName, f, 1);
           q = squeeze(q);
-          q = q(:,100:end-100);
+          q = q(:,100:end-10);
           textprogressbar((c/nFrames)*100);
 
           figure(1);

--- a/convertToH5_JK.asv
+++ b/convertToH5_JK.asv
@@ -1,0 +1,40 @@
+function [] = convertToH5_JK(sessionName,targetDir)
+% from 'convertToH5', add 'targetDir' to save the image in a different disk
+% drive
+% 2020/11/29 JK
+
+    if ~strcmp(targetDir(end), '\')
+        targetDir = [targetDir,'\'];
+    end
+    
+    % session name definition
+    sessionID = strsplit(sessionName, '\');
+    sessionID = sessionID{end};
+
+    % for a given session load the trials
+    trials = importdata([sessionName '.trials']);
+    load([sessionName, '.mat'])
+    
+    % vars
+    nPlanes = length(trials.frame_to_use);
+
+    framePlanes = trials.frame_to_use; % 2020/12/02 JK
+
+    % extract frames for each plane and save
+    for i = 1:nPlanes
+%     for i = 6:nPlanes
+       planeDir = fullfile(targetDir, ['plane_' num2str(i)]);
+       mkdir(planeDir);
+       planeFile = fullfile(planeDir, [sessionID, '_plane_', num2str(i), '.h5']);
+
+       % check frame dims
+       q = squeeze(jksbxreadframes(sessionName, framePlanes{i}, 1));
+       q = q(:,100:end-10,:);
+       meanImg = mean(q,3);
+
+       h5create(planeFile, '/data', [size(q, 1), size(q, 2) length(framePlanes{i})], 'DataType', 'uint16', 'ChunkSize',[size(q,1) size(q,2) 1])
+       h5write(planeFile,'/data',q)
+       
+    end
+end
+

--- a/convertToH5_JK.m
+++ b/convertToH5_JK.m
@@ -1,0 +1,42 @@
+function [] = convertToH5_JK(sessionName,targetDir)
+% from 'convertToH5', add 'targetDir' to save the image in a different disk
+% drive
+% 2020/11/29 JK
+
+    if ~strcmp(targetDir(end), '\')
+        targetDir = [targetDir,'\'];
+    end
+    
+    % session name definition
+    sessionID = strsplit(sessionName, '\');
+    sessionID = sessionID{end};
+
+    % for a given session load the trials
+    trials = importdata([sessionName '.trials']);
+    load([sessionName, '.mat'], 'info')
+    
+    % vars
+    nPlanes = length(trials.frame_to_use);
+    yStart = round(optotune_ringing_time/ (1000/info.resfreq) *(2-info.scanmode));
+    xStart = 100;
+    xDeadband = 10;
+
+    framePlanes = trials.frame_to_use; % 2020/12/02 JK
+
+    % extract frames for each plane and save
+    for i = 1:nPlanes
+%     for i = 6:nPlanes
+       planeDir = fullfile(targetDir, ['plane_' num2str(i)]);
+       mkdir(planeDir);
+       planeFile = fullfile(planeDir, [sessionID, '_plane_', num2str(i), '.h5']);
+
+       % load
+       q = squeeze(jksbxreadframes(sessionName, framePlanes{i}, 1));
+       q = q(yStart:end, xStart : end-xDeadband, :);
+
+       % save
+       h5create(planeFile, '/data', [size(q, 1), size(q, 2) length(framePlanes{i})], 'DataType', 'uint16', 'ChunkSize',[size(q,1) size(q,2) 1])
+       h5write(planeFile,'/data',q)       
+    end
+end
+

--- a/convertToH5_JK.m
+++ b/convertToH5_JK.m
@@ -1,4 +1,4 @@
-function [] = convertToH5_JK(sessionName,targetDir)
+function [] = convertToH5_JK(sessionName,targetDir,optotuneRingingTime)
 % from 'convertToH5', add 'targetDir' to save the image in a different disk
 % drive
 % 2020/11/29 JK
@@ -17,7 +17,7 @@ function [] = convertToH5_JK(sessionName,targetDir)
     
     % vars
     nPlanes = length(trials.frame_to_use);
-    yStart = round(optotune_ringing_time/ (1000/info.resfreq) *(2-info.scanmode));
+    yStart = round(optotuneRingingTime/ (1000/info.resfreq) *(2-info.scanmode));
     xStart = 100;
     xDeadband = 10;
 

--- a/convertToH5_JKtest.m
+++ b/convertToH5_JKtest.m
@@ -1,0 +1,65 @@
+function [] = convertToH5_JKtest(sessionName, targetDir)
+
+
+    if ~strcmp(targetDir(end), '\')
+        targetDir = [targetDir,'\'];
+    end
+    
+    % session name definition
+    sessionID = strsplit(sessionName, '\');
+    sessionID = sessionID{end};
+
+    % for a given session load the trials
+    trials = importdata([sessionName '.trials']);
+    
+    % vars
+    nPlanes = length(trials.frame_to_use);
+
+    framePlanes = trials.frame_to_use; % 2020/12/02 JK
+    
+    % extract frames for each plane and save
+%     figure(1);
+    for i = 1:nPlanes
+       planeDir = fullfile(targetDir, ['plane_' num2str(i), '_test']);
+       mkdir(planeDir);
+       planeFile = fullfile(planeDir, [sessionID, '_plane_', num2str(i), '.h5']);
+
+       % check frame dims
+       q = sbxread(sessionName, 1, 1);
+       q = squeeze(q);
+       q = q(:,100:end-10);
+%        meanImg = q;
+
+       h5create(planeFile, '/data', [size(q, 1), size(q, 2) Inf], 'DataType', 'uint16', 'ChunkSize',[size(q,1) size(q,2) 1])
+
+%        nFrames = length(framePlanes{1, i});
+%        refImg = zeros(size(q, 1), size(q, 2));
+       
+%        c = 1;
+
+%        textprogressbar('converting frames: ')
+       for fi = 1:length(framePlanes{i})
+          q = sbxread(sessionName, framePlanes{i}(fi), 1);
+          q = squeeze(q);
+          q = q(:,100:end-10);
+%           textprogressbar((c/nFrames)*100);
+
+%           figure(1);
+%           subplot(1,2,1); imshow(q);
+%           meanImg = (meanImg+q)./2;
+%           subplot(1,2,2); imshow(meanImg);      
+
+          h5write(planeFile,'/data',q,[1 1 fi],[size(q,1) size(q,2) 1]);
+%           refImg = refImg+double(q);
+
+%           c = c+1;
+       end
+%        textprogressbar('done');
+       
+%        refImg = refImg./nFrames;
+%        imwrite(uint16(refImg), fullfile(planeDir, [sessionID, '_plane_', num2str(i), '_refImg.tiff']))
+    end
+    
+%     save(fullfile(sessionName, 'framePlanes.mat'), 'framePlanes');
+end
+


### PR DESCRIPTION
- Adding jksbxsplittrial (creating new .trial file) to main conversion
- .h5 saving in chunk
- Removing ringing artifacts (8 ms at the beginning of every frame)
- Removing frames (just refer to trial.frame_to_use) and mean images (refer to .align file)
- Dependent on jksbxreadframes.m and jksbxsplittrial.m